### PR TITLE
Switch to using SmartString for Rhai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slug",
+ "smartstring",
  "syntect",
  "tantivy",
  "tempfile",
@@ -2448,7 +2449,6 @@ dependencies = [
  "once_cell",
  "rhai_codegen",
  "serde",
- "serde_json",
  "smallvec",
  "smartstring",
  "thin-vec",
@@ -2473,6 +2473,7 @@ dependencies = [
  "dashmap",
  "nanoid",
  "rhai",
+ "smartstring",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 resolver = "3"
-members = [
-    "poet",
-    "rhai_components",
-]
+members = ["poet", "rhai_components"]
 
 [workspace.dependencies]
 actix = "0.13.5"
@@ -41,11 +38,12 @@ notify = "8.2.0"
 notify-debouncer-full = "0.6.0"
 petgraph = { version = "0.8.2", features = ["serde", "serde_derive"] }
 rayon = { version = "1.11" }
-rhai = { version = "1.23.6", features = ["internals", "metadata", "no_closure", "serde", "serde_json", "sync"] }
+rhai = { version = "1.23.6", features = ["only_i32", "f32_float", "internals", "serde", "sync"] }
 schemars = "1.0.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.145"
 slug = "0.1.6"
+smartstring = "1.0.1"
 syntect = "5.2.0"
 tantivy = "0.25.0"
 tokio = { version = "1.45.1", features = ["full"] }

--- a/poet/Cargo.toml
+++ b/poet/Cargo.toml
@@ -46,6 +46,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slug = { workspace = true }
+smartstring = { workspace = true }
 syntect = { workspace = true }
 tantivy = { workspace = true }
 tokio = { workspace = true }

--- a/poet/src/eval_mdx_element.rs
+++ b/poet/src/eval_mdx_element.rs
@@ -11,6 +11,8 @@ use rhai_components::component_syntax::tag_name::TagName;
 use rhai_components::escape_html_attribute::escape_html_attribute;
 use rhai_components::rhai_template_renderer::RhaiTemplateRenderer;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 pub fn eval_mdx_element<TComponentContext>(
     attributes: &[AttributeContent],
     children: &[Node],
@@ -26,7 +28,8 @@ where
 
     let tag_name = TagName {
         name: name
-            .clone()
+            .as_ref()
+            .map(|n| SmartString::from(n))
             .ok_or_else(|| anyhow!("MdxJsxFlowElement without a name"))?,
     };
 

--- a/poet/src/rhai_helpers/render_hierarchy.rs
+++ b/poet/src/rhai_helpers/render_hierarchy.rs
@@ -10,7 +10,7 @@ fn render_node(
     context: &NativeCallContext,
     node: &ContentDocumentTreeNode,
     callback: &FnPtr,
-    nesting_level: i64,
+    nesting_level: i32,
 ) -> Result<Dynamic, Box<EvalAltResult>> {
     callback.call_within_context(
         context,

--- a/rhai_components/Cargo.toml
+++ b/rhai_components/Cargo.toml
@@ -10,4 +10,5 @@ anyhow = { workspace = true }
 dashmap = { workspace = true }
 nanoid = { workspace = true }
 rhai = { workspace = true }
+smartstring = { workspace = true }
 tokio = { workspace = true }

--- a/rhai_components/src/component_syntax/attribute.rs
+++ b/rhai_components/src/component_syntax/attribute.rs
@@ -1,7 +1,9 @@
 use super::attribute_value::AttributeValue;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Clone, Debug, Hash)]
 pub struct Attribute {
-    pub name: String,
+    pub name: SmartString,
     pub value: Option<AttributeValue>,
 }

--- a/rhai_components/src/component_syntax/attribute_value.rs
+++ b/rhai_components/src/component_syntax/attribute_value.rs
@@ -1,7 +1,9 @@
 use super::expression_reference::ExpressionReference;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Clone, Debug, Hash)]
 pub enum AttributeValue {
     Expression(ExpressionReference),
-    Text(String),
+    Text(SmartString),
 }

--- a/rhai_components/src/component_syntax/combine_output_symbols.rs
+++ b/rhai_components/src/component_syntax/combine_output_symbols.rs
@@ -14,6 +14,8 @@ use super::output_symbol::OutputSymbol;
 use super::tag::Tag;
 use crate::component_syntax::tag_name::TagName;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 pub fn combine_output_symbols(
     state: &Dynamic,
 ) -> Result<VecDeque<OutputSemanticSymbol>, ParseError> {
@@ -136,7 +138,7 @@ pub fn combine_output_symbols(
                     existing_text.push_str(&text);
                 }
                 _ => {
-                    semantic_symbols.push_back(OutputSemanticSymbol::Text(text.to_string()));
+                    semantic_symbols.push_back(OutputSemanticSymbol::Text(text));
                 }
             },
             OutputCombinedSymbol::TagLeftAngle => match semantic_symbols.back_mut() {
@@ -148,7 +150,7 @@ pub fn combine_output_symbols(
                         is_closing: false,
                         is_self_closing: false,
                         tag_name: TagName {
-                            name: String::new(),
+                            name: SmartString::new_const(),
                         },
                     }));
                 }

--- a/rhai_components/src/component_syntax/eval_tag_stack_node.rs
+++ b/rhai_components/src/component_syntax/eval_tag_stack_node.rs
@@ -4,6 +4,7 @@ use rhai::Array;
 use rhai::Dynamic;
 use rhai::EvalAltResult;
 use rhai::EvalContext;
+use rhai::ImmutableString;
 use rhai::Map;
 
 use super::attribute_value::AttributeValue;
@@ -13,28 +14,33 @@ use super::expression_collection::ExpressionCollection;
 use super::tag_stack_node::TagStackNode;
 use crate::rhai_call_template_function::rhai_call_template_function;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 pub fn eval_tag_stack_node(
     component_registry: Arc<ComponentRegistry>,
     eval_context: &mut EvalContext,
     current_node: &TagStackNode,
     expression_collection: &mut ExpressionCollection,
-) -> Result<String, Box<EvalAltResult>> {
+) -> Result<SmartString, Box<EvalAltResult>> {
     match current_node {
         TagStackNode::BodyExpression(expression_reference) => {
             let body_expression_result =
                 expression_collection.eval_expression(eval_context, expression_reference)?;
 
             if body_expression_result.is_array() {
-                let body_expresion_array: Array = body_expression_result.as_array_ref()?.to_vec();
-                let mut combined_ret = String::new();
+                let body_expression_array = body_expression_result.cast::<Array>();
+                let mut combined_ret = SmartString::new_const();
 
-                for item in body_expresion_array {
+                for item in body_expression_array {
                     combined_ret.push_str(&item.to_string());
                 }
 
                 Ok(combined_ret)
+            } else if body_expression_result.is_string() {
+                let body_expression_string = body_expression_result.cast::<ImmutableString>();
+                Ok(body_expression_string.into())
             } else {
-                Ok(body_expression_result.to_string())
+                Ok(body_expression_result.to_string().into())
             }
         }
         TagStackNode::Tag {
@@ -42,7 +48,7 @@ pub fn eval_tag_stack_node(
             is_closed,
             opening_tag,
         } => {
-            let mut result = String::new();
+            let mut result = SmartString::new_const();
 
             if let Some(opening_tag) = &opening_tag
                 && !opening_tag.tag_name.is_component()
@@ -63,7 +69,9 @@ pub fn eval_tag_stack_node(
                 && *is_closed
                 && !opening_tag.tag_name.is_component()
             {
-                result.push_str(&format!("</{}>", opening_tag.tag_name.name));
+                result.push_str("</");
+                result.push_str(&opening_tag.tag_name.name);
+                result.push_str(">");
 
                 return Ok(result);
             }
@@ -76,7 +84,7 @@ pub fn eval_tag_stack_node(
 
                     for attribute in &opening_tag.attributes {
                         props.insert(
-                            attribute.name.clone().into(),
+                            attribute.name.clone(),
                             if let Some(value) = &attribute.value {
                                 match value {
                                     AttributeValue::Expression(expression_reference) => {
@@ -86,7 +94,7 @@ pub fn eval_tag_stack_node(
                                     AttributeValue::Text(text) => text.into(),
                                 }
                             } else {
-                                true.into()
+                                Dynamic::TRUE
                             },
                         );
                     }
@@ -94,15 +102,12 @@ pub fn eval_tag_stack_node(
                     props
                 };
 
-                let context = match eval_context.scope().get("context") {
-                    Some(context) => context.clone(),
-                    None => {
-                        return Err(EvalAltResult::ErrorRuntime(
-                            "'context' variable not found in scope".into(),
-                            rhai::Position::NONE,
-                        )
-                        .into());
-                    }
+                let Some(context) = eval_context.scope().get("context").cloned() else {
+                    return Err(EvalAltResult::ErrorRuntime(
+                        "'context' variable not found in scope".into(),
+                        rhai::Position::NONE,
+                    )
+                    .into());
                 };
 
                 Ok(rhai_call_template_function(

--- a/rhai_components/src/component_syntax/output_combined_symbol.rs
+++ b/rhai_components/src/component_syntax/output_combined_symbol.rs
@@ -1,14 +1,16 @@
 use super::attribute_value::AttributeValue;
 use super::expression_reference::ExpressionReference;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Debug)]
 pub enum OutputCombinedSymbol {
     BodyExpression(ExpressionReference),
-    Text(String),
+    Text(SmartString),
     TagLeftAngle,
     TagCloseBeforeName,
-    TagName(String),
-    TagAttributeName(String),
+    TagName(SmartString),
+    TagAttributeName(SmartString),
     TagAttributeValue(AttributeValue),
     TagPadding,
     TagSelfClose,

--- a/rhai_components/src/component_syntax/output_semantic_symbol.rs
+++ b/rhai_components/src/component_syntax/output_semantic_symbol.rs
@@ -1,9 +1,11 @@
 use super::expression_reference::ExpressionReference;
 use super::tag::Tag;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Debug)]
 pub enum OutputSemanticSymbol {
     BodyExpression(ExpressionReference),
     Tag(Tag),
-    Text(String),
+    Text(SmartString),
 }

--- a/rhai_components/src/component_syntax/output_symbol.rs
+++ b/rhai_components/src/component_syntax/output_symbol.rs
@@ -1,14 +1,16 @@
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Clone, Debug)]
 pub enum OutputSymbol {
     BodyExpression,
-    Text(String),
+    Text(SmartString),
     TagLeftAnglePlusWhitespace,
-    TagCloseBeforeNamePlusWhitespace(String),
-    TagName(String),
+    TagCloseBeforeNamePlusWhitespace(SmartString),
+    TagName(SmartString),
     TagPadding,
-    TagAttributeName(String),
+    TagAttributeName(SmartString),
     TagAttributeValueExpression,
-    TagAttributeValueString(String),
+    TagAttributeValueString(SmartString),
     TagSelfClose,
     TagRightAngle,
 }

--- a/rhai_components/src/component_syntax/parse_component.rs
+++ b/rhai_components/src/component_syntax/parse_component.rs
@@ -77,7 +77,7 @@ pub fn parse_component(
                     Ok(Some("$raw$".into()))
                 }
                 _ => {
-                    push_to_state(state, OutputSymbol::Text(last_symbol.to_string()))?;
+                    push_to_state(state, OutputSymbol::Text(last_symbol.into()))?;
                     state.set_tag(ParserState::Body as i32);
 
                     Ok(Some("$raw$".into()))
@@ -107,14 +107,14 @@ pub fn parse_component(
                 "/" => {
                     push_to_state(
                         state,
-                        OutputSymbol::TagCloseBeforeNamePlusWhitespace(last_symbol.to_string()),
+                        OutputSymbol::TagCloseBeforeNamePlusWhitespace(last_symbol.into()),
                     )?;
                     state.set_tag(ParserState::TagCloseBeforeNamePlusWhitespace as i32);
 
                     Ok(Some("$raw$".into()))
                 }
                 _ => {
-                    push_to_state(state, OutputSymbol::TagName(last_symbol.to_string()))?;
+                    push_to_state(state, OutputSymbol::TagName(last_symbol.into()))?;
                     state.set_tag(ParserState::TagName as i32);
 
                     Ok(Some("$raw$".into()))
@@ -124,14 +124,14 @@ pub fn parse_component(
                 _ if last_symbol.trim().is_empty() => {
                     push_to_state(
                         state,
-                        OutputSymbol::TagCloseBeforeNamePlusWhitespace(last_symbol.to_string()),
+                        OutputSymbol::TagCloseBeforeNamePlusWhitespace(last_symbol.into()),
                     )?;
                     state.set_tag(ParserState::TagCloseBeforeNamePlusWhitespace as i32);
 
                     Ok(Some("$raw$".into()))
                 }
                 _ => {
-                    push_to_state(state, OutputSymbol::TagName(last_symbol.to_string()))?;
+                    push_to_state(state, OutputSymbol::TagName(last_symbol.into()))?;
                     state.set_tag(ParserState::TagName as i32);
 
                     Ok(Some("$raw$".into()))
@@ -151,7 +151,7 @@ pub fn parse_component(
                     Ok(Some("$raw$".into()))
                 }
                 _ => {
-                    push_to_state(state, OutputSymbol::TagName(last_symbol.to_string()))?;
+                    push_to_state(state, OutputSymbol::TagName(last_symbol.into()))?;
                     state.set_tag(ParserState::TagName as i32);
 
                     Ok(Some("$raw$".into()))
@@ -182,10 +182,7 @@ pub fn parse_component(
                     Ok(Some(">".into()))
                 }
                 _ => {
-                    push_to_state(
-                        state,
-                        OutputSymbol::TagAttributeName(last_symbol.to_string()),
-                    )?;
+                    push_to_state(state, OutputSymbol::TagAttributeName(last_symbol.into()))?;
                     state.set_tag(ParserState::TagAttributeName as i32);
 
                     Ok(Some("$raw$".into()))
@@ -216,10 +213,7 @@ pub fn parse_component(
                     Ok(Some("$raw$".into()))
                 }
                 _ => {
-                    push_to_state(
-                        state,
-                        OutputSymbol::TagAttributeName(last_symbol.to_string()),
-                    )?;
+                    push_to_state(state, OutputSymbol::TagAttributeName(last_symbol.into()))?;
                     state.set_tag(ParserState::TagAttributeName as i32);
 
                     Ok(Some("$raw$".into()))
@@ -243,10 +237,7 @@ pub fn parse_component(
                     Ok(Some("$inner$".into()))
                 }
                 _ => {
-                    push_to_state(
-                        state,
-                        OutputSymbol::TagAttributeName(last_symbol.to_string()),
-                    )?;
+                    push_to_state(state, OutputSymbol::TagAttributeName(last_symbol.into()))?;
                     state.set_tag(ParserState::TagContent as i32);
 
                     Ok(Some("$raw$".into()))
@@ -261,7 +252,7 @@ pub fn parse_component(
                 _ => {
                     push_to_state(
                         state,
-                        OutputSymbol::TagAttributeValueString(last_symbol.to_string()),
+                        OutputSymbol::TagAttributeValueString(last_symbol.into()),
                     )?;
                     state.set_tag(ParserState::TagAttributeValueString as i32);
 

--- a/rhai_components/src/component_syntax/tag_name.rs
+++ b/rhai_components/src/component_syntax/tag_name.rs
@@ -1,6 +1,8 @@
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Clone, Debug, Hash)]
 pub struct TagName {
-    pub name: String,
+    pub name: SmartString,
 }
 
 impl TagName {

--- a/rhai_components/src/component_syntax/tag_stack_node.rs
+++ b/rhai_components/src/component_syntax/tag_stack_node.rs
@@ -1,6 +1,8 @@
 use super::expression_reference::ExpressionReference;
 use super::tag::Tag;
 
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
 #[derive(Clone, Debug, Hash)]
 pub enum TagStackNode {
     BodyExpression(ExpressionReference),
@@ -9,5 +11,5 @@ pub enum TagStackNode {
         is_closed: bool,
         opening_tag: Option<Tag>,
     },
-    Text(String),
+    Text(SmartString),
 }

--- a/rhai_components/src/rhai_call_template_function.rs
+++ b/rhai_components/src/rhai_call_template_function.rs
@@ -2,19 +2,25 @@ use anyhow::Result;
 use rhai::AST;
 use rhai::Engine;
 use rhai::FuncArgs;
+use rhai::ImmutableString;
 use rhai::Position;
 use rhai::Scope;
+
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
 
 pub fn rhai_call_template_function(
     engine: &Engine,
     component_name: &str,
     args: impl FuncArgs,
-) -> Result<String> {
+) -> Result<SmartString> {
     let module = engine
         .module_resolver()
         .resolve(engine, None, component_name, Position::NONE)?;
 
     let tmp_ast = AST::new([], module);
 
-    Ok(engine.call_fn(&mut Scope::new(), &tmp_ast, "template", args)?)
+    let result =
+        engine.call_fn::<ImmutableString>(&mut Scope::new(), &tmp_ast, "template", args)?;
+
+    Ok(result.into())
 }

--- a/rhai_components/src/rhai_template_renderer.rs
+++ b/rhai_components/src/rhai_template_renderer.rs
@@ -70,6 +70,7 @@ impl RhaiTemplateRenderer {
                 &component_reference.name,
                 (context, props, content),
             )
+            .map(Into::into)
         } else {
             Err(anyhow!("Template '{name}' not found"))
         }


### PR DESCRIPTION
This is an experiment in using the `smartstring` crate for short strings.

So far I've only turned Rhai-related stuff to Smart Strings.  See if it creates any substantial performance improvements.

In my own usage, I always find that reducing allocations to be key when working with large amounts of string manipulation.
